### PR TITLE
remove single quotes in npm script; windows compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-material-jspm-mobx-starter",
   "version": "0.2.0",
   "scripts": {
-    "serve": "browser-sync start --files 'src/**/*.html,src/**/*.css,src/**/*.js' --server 'src'"
+    "serve": "browser-sync start --files src/**/*.html,src/**/*.css,src/**/*.js --server src"
   },
   "devDependencies": {
     "browser-sync": "^2.10.1",


### PR DESCRIPTION
don't think quotes are needed on MacOS either; if I'm wrong, you can escape double quotes and it will work fine in Windows.
